### PR TITLE
make infinite play smooth in the border transition

### DIFF
--- a/src/js/spotlight.js
+++ b/src/js/spotlight.js
@@ -1027,7 +1027,7 @@ export function prev(){
         return goto(current_slide - 1);
     }
     else if(playing || options_infinite){
-
+        prepareStyle(slider, "transform", "translateX(-" + slide_count * 100 + "%)");
         return goto(slide_count);
     }
 }
@@ -1039,7 +1039,7 @@ export function next(){
         return goto(current_slide + 1);
     }
     else if(playing || options_infinite){
-
+        prepareStyle(slider, "transform", "translateX(100%)");
         return goto(1);
     }
 }


### PR DESCRIPTION
When infinite mode was open, it is not smooth on the border, I fixed this issue in the PR and it is now very smooth in infinite slide mode.