### PR TITLE
Info icon and hotkey to toggle the footer

### DIFF
--- a/src/css/images.less
+++ b/src/css/images.less
@@ -11,3 +11,4 @@
 @pause: "../img/pause.svg";
 @download: "../img/download.svg";
 @error: "../img/error.svg";
+@info: "../img/info.svg";

--- a/src/css/spotlight.css
+++ b/src/css/spotlight.css
@@ -235,6 +235,9 @@
 .spl-close {
   background-image: url("../img/close.svg");
 }
+.spl-info {
+  background-image: url("../img/info.svg");
+}
 .spl-prev,
 .spl-next {
   position: absolute;

--- a/src/css/spotlight.less
+++ b/src/css/spotlight.less
@@ -256,6 +256,9 @@
 .spl-close{
   background-image: url(@close);
 }
+.spl-info{
+  background-image: url(@info);
+}
 .spl-prev,
 .spl-next{
   position: absolute;

--- a/src/img/info.svg
+++ b/src/img/info.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;">
+    <circle cx="12" cy="12" r="9.6" style="fill:none;stroke:white;stroke-width:1.92px;"/>
+    <g transform="matrix(20,0,0,20,8.26385,19.3395)">
+        <path d="M0.288,-0.659C0.288,-0.633 0.279,-0.612 0.261,-0.594C0.244,-0.577 0.223,-0.569 0.198,-0.569C0.174,-0.569 0.152,-0.578 0.135,-0.595C0.117,-0.613 0.108,-0.634 0.108,-0.659C0.108,-0.684 0.117,-0.705 0.135,-0.722C0.152,-0.74 0.174,-0.749 0.198,-0.749C0.223,-0.749 0.244,-0.74 0.261,-0.722C0.279,-0.705 0.288,-0.684 0.288,-0.659ZM0.354,-0.118L0.354,-0L0.037,-0L0.037,-0.118L0.115,-0.118L0.115,-0.393L0.037,-0.393L0.037,-0.513L0.278,-0.513L0.278,-0.118L0.354,-0.118Z" style="fill:white;fill-rule:nonzero;"/>
+    </g>
+</svg>

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -1,5 +1,6 @@
 export const controls = [
 
+    "info",
     "theme",
     "download",
     "play",
@@ -15,6 +16,7 @@ export const controls = [
 
 export const controls_default = {
 
+    "info": 1,
     "page": 1,
     "close": 1,
     "autofit": 1,
@@ -41,5 +43,6 @@ export const keycodes = {
     PLUS: 187,
     DOWN: 40,
     NUMBLOCK_MINUS: 109,
-    MINUS: 189
+    MINUS: 189,
+    INFO: 73
 };

--- a/src/js/spotlight.js
+++ b/src/js/spotlight.js
@@ -84,6 +84,7 @@ let media_next = createElement("img");
 let slider;
 let header;
 let footer;
+let footer_visible = 0;
 let title;
 let description;
 let button;
@@ -152,6 +153,7 @@ export function init(){
         controls.pop(); // => "fullscreen"
     }
 
+    addControl("info", info);
     addControl("autofit", autofit);
     addControl("zoom-in", zoom_in);
     addControl("zoom-out", zoom_out);
@@ -202,7 +204,7 @@ export function init(){
 
     function getOneByClass(classname){
 
-        //console.log("getOneByClass", class_name);
+        //console.log("getOneByClass", classname);
 
         return controls_dom[classname] = getByClass("spl-" + classname, widget)[0];
     }
@@ -701,7 +703,7 @@ function update_scroll(force_scale){
 
 function update_panel(x, y){
 
-    ////console.log("update_panel", x, y);
+    //console.log("update_panel", x, y);
 
     setStyle(panel, "transform", x || y ? "translate(" + x + "px, " + y + "px)" : "");
 }
@@ -794,6 +796,11 @@ function key_listener(event){
             case keycodes.MINUS:
                 zoom_enabled && zoom_out();
                 break;
+
+            case keycodes.INFO:
+                info();
+                break;
+
         }
     }
 }
@@ -991,7 +998,7 @@ function end(e){
 
 function move(e){
 
-    ////console.log("move");
+    //console.log("move");
 
     cancelEvent(e);
 
@@ -1204,6 +1211,15 @@ export function zoom(factor){
     scale = factor || 1;
 
     update_scroll();
+}
+
+export function info(){
+
+    //console.log("info");
+
+    footer_visible = !footer_visible;
+    toggleVisibility(footer, footer_visible);
+
 }
 
 function disable_autoresizer(){
@@ -1474,6 +1490,8 @@ function setup_page(direction){
         }
     }
 
+    footer && toggleVisibility(footer, 0);
+
     prepare(direction);
     update_slider(current_slide - 1);
     removeClass(spinner, "error");
@@ -1501,7 +1519,7 @@ function setup_page(direction){
 
     options_autohide || addClass(widget, "menu");
 
-    toggleVisibility(footer, has_content);
+    toggleVisibility(footer, footer_visible && has_content);
     toggleVisibility(page_prev, options_infinite || (current_slide > 1));
     toggleVisibility(page_next, options_infinite || (current_slide < slide_count));
     setText(page, slide_count > 1 ? current_slide + " / " + slide_count : "");


### PR DESCRIPTION
Added an icon for "info" and a hotkey "i" to toggle the visibility of the footer (title and description).
In the function "setup_page" I added a call to toggleVisibility(footer, ... to fix some drawing issues. The issues are gone in Firefox/Win, but still there in Safari/iOS.
My goal is to have a place where I can display technical data about the current image (EXIF data, meta data).
Currently the footer (title & description) works ok, but is too limited in terms of formatting.
![image](https://user-images.githubusercontent.com/80953108/122183077-2d41e000-ce8b-11eb-919a-6f9ffaf9afd1.png)
