### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ You can also load modules via CDN, e.g.:
 
 ```html
 <script type="module">
-  import Spotlight from "https://unpkg.com/spotlight@0.7.8/src/js/spotlight.js";
+  import Spotlight from "https://unpkg.com/spotlight.js@0.7.8/src/js/spotlight.js";
 </script>
 ```
 
@@ -267,7 +267,7 @@ This also works with dynamically loaded content. There is no need to inject list
 Alternatively you can use non-anchor elements also:
 
 ```html
-<div class="spotlight" data-src="img1.jpg">
+<a class="spotlight" data-src="img1.jpg">
     <!-- image or any other elements -->
 </a>
 ```

--- a/README.md
+++ b/README.md
@@ -267,9 +267,9 @@ This also works with dynamically loaded content. There is no need to inject list
 Alternatively you can use non-anchor elements also:
 
 ```html
-<a class="spotlight" data-src="img1.jpg">
+<div class="spotlight" data-src="img1.jpg">
     <!-- image or any other elements -->
-</a>
+</div>
 ```
 
 Pretty much the same like anchors but uses ___data-src___ instead of ___href___.


### PR DESCRIPTION
This commit proposes two modifications to the README.md:
1. The unpkg.com link on line 235 seems to be invalid. Looking at your npm profile, it looks like the correct package is `spotlight.js`, which is what I changed it to.
2. On line 270, an example of non-anchor elements if given. However, the HTML-tags do not correspond. Based on the earlier examples, I assume the `div` tag should be a `a` tag.