### PR TITLE
add force parameter to init when body is swapped

### DIFF
--- a/src/js/spotlight.js
+++ b/src/js/spotlight.js
@@ -106,10 +106,9 @@ let prefix_request, prefix_exit;
 
 addListener(document, "click", dispatch);
 
-export function init(){
+export function init({ force = false }){
 
-    if(body){
-
+    if (body && !force) {
         return;
     }
 


### PR DESCRIPTION
When the HTML `body` tag is swapped by a JS framework navigation tool like [Hotwire's Turbo Drive](https://turbo.hotwired.dev/) you need to re-init spotlight.

Currently it's impossible because body is a global variable that does not get cleaned up on 'fake' JS navigations through turbo.

This commit introduces a new force parameter that fixes this.

Note: I did not manage to build the project locally so this only introduces the change in `src`